### PR TITLE
fix: resolve combinatorial loop between backend and cache

### DIFF
--- a/ip/pipeline/rtl/muntjac_backend.sv
+++ b/ip/pipeline/rtl/muntjac_backend.sv
@@ -331,19 +331,19 @@ module muntjac_backend import muntjac_pkg::*; #(
     // control registers so they effectively conflict with any other instruction.
     struct_hazard = !ex1_ready || de_ex_decoded.ex_valid;
     unique case (de_ex_decoded.op_type)
-      OP_MEM: begin
-        if (!mem_ready) struct_hazard = 1'b1;
-      end
-      OP_MUL: begin
-        if (!mul_ready) struct_hazard = 1'b1;
-      end
-      OP_DIV: begin
-        if (!div_ready) struct_hazard = 1'b1;
-      end
-      OP_FP: begin
-        if (!fpu_ready) struct_hazard = 1'b1;
-      end
       OP_SYSTEM: struct_hazard = 1'b1;
+      default:;
+    endcase
+  end
+
+  logic unit_ready;
+  always_comb begin
+    unit_ready = 1'b1;
+    unique case (de_ex_decoded.op_type)
+      OP_MEM: unit_ready = mem_ready;
+      OP_MUL: unit_ready = mul_ready;
+      OP_DIV: unit_ready = div_ready;
+      OP_FP:  unit_ready = fpu_ready;
       default:;
     endcase
   end
@@ -404,8 +404,9 @@ module muntjac_backend import muntjac_pkg::*; #(
   if_reason_e sys_pc_redirect_reason;
   logic [63:0] sys_pc_redirect_target;
 
-  wire ex_issue = de_ex_valid && !data_hazard && !struct_hazard && !control_hazard;
-  assign de_ex_ready = (!data_hazard && !struct_hazard) || control_hazard;
+  wire ex_issue_provisional = de_ex_valid && !data_hazard && !struct_hazard && !control_hazard;
+  wire ex_issue = ex_issue_provisional && unit_ready;
+  assign de_ex_ready = (!data_hazard && !struct_hazard && unit_ready) || control_hazard;
 
   always_comb begin
     exception_issue = 1'b0;
@@ -1004,7 +1005,7 @@ module muntjac_backend import muntjac_pkg::*; #(
     .operand_b_i  (ex_rs2),
     .req_word_i   (word),
     .req_op_i     (de_ex_decoded.mul_op),
-    .req_valid_i  (ex_issue && de_ex_decoded.op_type == OP_MUL),
+    .req_valid_i  (ex_issue_provisional && de_ex_decoded.op_type == OP_MUL),
     .req_ready_o  (mul_ready),
     .resp_valid_o (mul_valid),
     .resp_value_o (mul_data)
@@ -1018,7 +1019,7 @@ module muntjac_backend import muntjac_pkg::*; #(
     .operand_b_i  (ex_rs2),
     .req_op_i     (de_ex_decoded.div_op),
     .req_word_i   (word),
-    .req_valid_i  (ex_issue && de_ex_decoded.op_type == OP_DIV),
+    .req_valid_i  (ex_issue_provisional && de_ex_decoded.op_type == OP_DIV),
     .req_ready_o  (div_ready),
     .resp_valid_o (div_valid),
     .resp_value_o (div_data)
@@ -1036,7 +1037,7 @@ module muntjac_backend import muntjac_pkg::*; #(
       .foperand_c_i (ex_frs3),
       .req_op_i     (de_ex_decoded.fp_op),
       .req_double_i (!word),
-      .req_valid_i  (ex_issue && de_ex_decoded.op_type == OP_FP),
+      .req_valid_i  (ex_issue_provisional && de_ex_decoded.op_type == OP_FP),
       .req_rm_i     (muntjac_fpu_pkg::rounding_mode_e'(de_ex_decoded.exception.tval[14:12] == 3'b111 ? frm : de_ex_decoded.exception.tval[14:12])),
       .req_ready_o  (fpu_ready),
       .resp_valid_o (fpu_valid),
@@ -1055,7 +1056,7 @@ module muntjac_backend import muntjac_pkg::*; #(
   //
 
   priv_lvl_e data_prv;
-  assign dcache_h2d_o.req_valid    = ex_issue && de_ex_decoded.op_type == OP_MEM;
+  assign dcache_h2d_o.req_valid    = ex_issue_provisional && de_ex_decoded.op_type == OP_MEM;
   assign dcache_h2d_o.req_op       = de_ex_decoded.mem_op;
   assign dcache_h2d_o.req_amo      = de_ex_decoded.exception.tval[31:25];
   assign dcache_h2d_o.req_address  = sum;


### PR DESCRIPTION
Fixes a fatal zero-delay oscillation bug in Muntjac core simulation caused by a circular combinatorial dependency violating valid/ready handshake rules.

### Summary of Commits
- `fix: resolve combinatorial loop between backend and cache`: Removed functional unit ready checks from structural hazard logic to untangle the combinatorial loop where `req_valid` depended on `req_ready`. Added `ex_issue_provisional` to independently assert `req_valid`, while using a new `unit_ready` signal to maintain pipeline stalls correctly.

This pull request has been created by an automated coding assistant, with human supervision.

Please fix the bug described in this report:

### Describe the bug
When simulating the Muntjac core using an event-driven simulator like Vivado XSIM, the simulation fails immediately at $t=0$ with a fatal iteration limit error: Fatal Error: Iteration limit reached. Possible zero delay oscillation detected where simulation time can not advance.

This is caused by a circular combinatorial dependency violating standard valid/ready handshake rules: the backend's req_valid signal combinationally depends on the cache's req_ready signal, but the cache's req_ready signal combinationally depends on req_valid through its internal arbiter.

### Root Cause / Trace
1. muntjac_backend.sv: req_valid depends on mem_ready (req_ready).
2. muntjac_dcache.sv: req_ready depends on req_valid via arbiter.

### Proposed Fix
In muntjac_backend.sv, the mem_ready check should be removed from the structural hazard detection for OP_MEM, allowing req_valid to assert independently of req_ready. Stalling the pipeline should be handled by the pipeline stage registers not advancing when req_valid && !req_ready.
create PR