### PR TITLE
fix(sim): resolve verilator 4.038 build errors and missing pins

### DIFF
--- a/flows/verilator/rtl/pipeline_wrapper.sv
+++ b/flows/verilator/rtl/pipeline_wrapper.sv
@@ -89,6 +89,7 @@ module pipeline_wrapper import muntjac_pkg::*; #(
       .irq_external_m_i,
       .irq_external_s_i,
       .hart_id_i,
+      .hpm_event_i ('0),
       .dbg_o
   );
 

--- a/flows/verilator/src/simulation.h
+++ b/flows/verilator/src/simulation.h
@@ -9,6 +9,7 @@
 #include <iostream>
 #include <fstream>
 #include <verilated.h>
+#include <verilated_cov.h>
 
 // Verilator doesn't allow VCD and FST tracing simultaneously.
 // FST is faster and smaller, but only supported by GTKWave.
@@ -109,7 +110,7 @@ protected:
     }
 #endif
     if (coverage_on)
-      Verilated::threadContextp()->coveragep()->write(coverage_file.c_str());
+      VerilatedCov::write(coverage_file.c_str());
   }
 
 public:


### PR DESCRIPTION
This PR fixes Verilator build errors when running `make sim-pipeline` and `make sim-core`.

Summary of changes:
- `flows/verilator/src/simulation.h`: Replaced `Verilated::threadContextp()->coveragep()->write()` with `VerilatedCov::write()` and included `<verilated_cov.h>` to support Verilator 4.038.
- `flows/verilator/rtl/pipeline_wrapper.sv`: Tied off the missing `hpm_event_i` pin to fix the `%Warning-PINMISSING` error.

This pull request has been created by an automated coding assistant, with human supervision.
Prompt: run `make sim-pipeline`, fix errors
continue?
send pr
