### PR TITLE
fix: add variable initialization for xsim compatibility

### DIFF
--- a/ip/pipeline/rtl/muntjac_backend.sv
+++ b/ip/pipeline/rtl/muntjac_backend.sv
@@ -85,7 +85,8 @@ module muntjac_backend import muntjac_pkg::*; #(
   // Decoder //
   /////////////
 
-  logic de_ex_valid;
+  // See comment on valid initialization in regslice.sv.
+  logic de_ex_valid = 1'b0;
   logic de_ex_ready;
   decoded_instr_t de_ex_decoded;
   logic [63:0] de_ex_rs1;

--- a/ip/pipeline/rtl/muntjac_frontend.sv
+++ b/ip/pipeline/rtl/muntjac_frontend.sv
@@ -230,7 +230,9 @@ module muntjac_frontend import muntjac_pkg::*; #(
   assign icache_h2d_o.req_atp = redirect_valid_q && align_ready ? redirect_atp_q : atp_latch;
   assign icache_h2d_o.req_prv = redirect_valid_q && align_ready ? redirect_prv_q : prv_latch;
 
-  logic resp_latched;
+  // See comment on valid initialization in regslice.sv.
+  // Reset value is 1'b1 (response already latched at startup).
+  logic resp_latched = 1'b1;
   logic [31:0] resp_instr_latched;
   logic resp_exception_latched;
   exc_cause_e resp_ex_code_latched;

--- a/vendor/OpenIP/rtl/regslice.sv
+++ b/vendor/OpenIP/rtl/regslice.sv
@@ -57,8 +57,14 @@ module openip_regslice #(
         // We need two buffers to achieve 100% throughput.
         TYPE buffer;
         TYPE skid_buffer;
-        logic valid;
-        logic skid_valid;
+        // Variable initialization is required for event-driven simulators
+        // (e.g. Vivado xsim). These registers use async reset, but at time 0
+        // no edge has occurred yet, so always_comb blocks see X and create a
+        // delta cycle oscillation. The init value must match the async reset
+        // value. This has no effect on synthesis.
+        // See: https://github.com/lowRISC/muntjac/issues/4
+        logic valid = 1'b0;
+        logic skid_valid = 1'b0;
 
         // We can accept write if the skid buffer is still empty.
         assign w_ready = !skid_valid;
@@ -97,7 +103,8 @@ module openip_regslice #(
 
         // This is equivalent to a depth 1 FIFO.
         TYPE buffer;
-        logic valid;
+        // See comment on valid initialization above.
+        logic valid = 1'b0;
 
         // We can read if the buffer is not empty and write if it is.
         assign w_ready = !valid;
@@ -122,7 +129,8 @@ module openip_regslice #(
     else if (FORWARD) begin
 
         TYPE buffer;
-        logic valid;
+        // See comment on valid initialization above.
+        logic valid = 1'b0;
 
         // We can read if the buffer is not empty.
         assign r_valid = valid;
@@ -151,7 +159,8 @@ module openip_regslice #(
         // This is equivalent to a fall-through depth 1 FIFO.
 
         TYPE buffer;
-        logic valid;
+        // See comment on valid initialization above.
+        logic valid = 1'b0;
 
         // We can read if the buffer is not empty, or data is fed in directly from w_data.
         assign r_valid = valid || w_valid;


### PR DESCRIPTION
## Summary

- Add SystemVerilog variable initialization to registers that use async reset but lack init values
- Prevents delta cycle oscillation at time 0 in event-driven simulators (Vivado xsim)
- Initialization values match async reset values exactly, so no effect on synthesis

### Changed files
- `vendor/OpenIP/rtl/regslice.sv`: `valid` and `skid_valid` in all 4 regslice modes
- `ip/pipeline/rtl/muntjac_backend.sv`: `de_ex_valid`
- `ip/pipeline/rtl/muntjac_frontend.sv`: `resp_latched` (reset value `1'b1`)

### Root cause
At time 0, no clock or reset edge has occurred. Registers declared as `logic valid;` hold X. `always_comb` blocks evaluate with X inputs and create a non-converging delta cycle loop. Adding `= 1'b0` (or `= 1'b1` for `resp_latched`) gives defined values from delta 0.

Fixes: https://github.com/lowRISC/muntjac/issues/4

## Test plan
- [ ] Verify `muntjac_core` simulates in Vivado xsim without delta cycle oscillation
- [ ] Verify simulation produces correct waveforms (reset behavior unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)